### PR TITLE
Add Chinese (simplified) translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Ubuntu `sudo apt install python-nautilus python3-gi`
 4. Restart the Nautilus (`nautilus -q`)
 
 ## Currently supported languages 
+- Chinese
 - English
 - French
 - German

--- a/translations/zh.json
+++ b/translations/zh.json
@@ -1,0 +1,8 @@
+{
+  "copy_path": "复制路径",
+  "copy_paths": "复制各个路径",
+  "copy_name": "复制文件名",
+  "copy_names": "复制各个文件名",
+  "copy_uri": "复制URI",
+  "copy_uris": "复制各个URI"
+}


### PR DESCRIPTION
I've added a translation file for Chinese (simplified). I'm not sure if I should name the file zh_cn.json or just zh.json but I'm submitting it as zh.json for now. Please let me know if this is not the right thing to do.

Since there are no plurals in Chinese, I've replaced "Copy ...s" with "Copy each ..." to differentiate between copying paths for one and more than one items. This is not strictly necessary but I thought it would make it clearer to the user whether they are dealing with one file or more than one.