### PR TITLE
Update installation instructions for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 Fedora `sudo dnf install nautilus-python python3-gobject`
 
-Ubuntu `sudo apt install python-nautilus python3-gi`
+Ubuntu `sudo apt install python3-nautilus python3-gi`
 
 Arch `sudo pacman -S python-nautilus python-gobject`
 


### PR DESCRIPTION
On current Ubuntu versions (20.04 LTS and 21.10), the Python bindings for Nautilus are provided by the package "python3-nautilus".