### PR TITLE
Fix missing comma in French translation

### DIFF
--- a/translations/fr.json
+++ b/translations/fr.json
@@ -2,7 +2,7 @@
   "copy_path": "Copier le chemin",
   "copy_paths": "Copier les chemins",
   "copy_name": "Copier le nom",
-  "copy_names": "Copier les noms"
+  "copy_names": "Copier les noms",
   "copy_uri": "Copier l'URI",
   "copy_uris": "Copier les URI",
   "copy_content": "Copier le contenu"


### PR DESCRIPTION
The French translation file (`translations/fr.json`) was missing a comma after `"copy_names"`, causing a `JSONDecodeError` at runtime when building the context menu on French systems.

This made the extension silently fail to display any menu entries for users with a French locale.